### PR TITLE
Add pandemic-era clade 1 definition

### DIFF
--- a/.auto-generated/clades-long.tsv
+++ b/.auto-generated/clades-long.tsv
@@ -1,4 +1,7 @@
 clade	gene	site	alt
+1	HA1	31	N
+1	HA1	97	D
+1	HA1	125	N
 2	HA1	31	D
 2	HA1	162	N
 2	HA1	186	T

--- a/.auto-generated/clades.tsv
+++ b/.auto-generated/clades.tsv
@@ -1,4 +1,7 @@
 clade	gene	site	alt
+1	HA1	31	N
+1	HA1	97	D
+1	HA1	125	N
 2	HA1	31	D
 2	HA1	162	N
 2	HA1	186	T

--- a/clades/1.yml
+++ b/clades/1.yml
@@ -1,0 +1,14 @@
+name: '1'
+short_name: '1'
+parent: none
+representatives: []
+defining_mutations:
+- locus: HA1
+  position: 31
+  state: N
+- locus: HA1
+  position: 97
+  state: D
+- locus: HA1
+  position: 125
+  state: N


### PR DESCRIPTION
Adds a YAML file and autogenerated TSV files for the pandemic-era clade 1. The clade 1 definition uses the ancestral alleles at positions that change in subsequent clades including clades 2, 4, and 6.

The following screenshot of [an earlier historical H1N1pdm HA 12y tree colored by genotypes at these positions](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/12y@2019-02-01?c=gt-HA1_31,97,125&d=tree&gmax=1052&gmin=72&p=full) (31, 97, and 125) shows where clade 1 will be annotated in future trees after we merge this PR.

<img width="1139" alt="image" src="https://github.com/influenza-clade-nomenclature/seasonal_A-H1N1pdm_HA/assets/85372/f3058e55-f771-46bb-8610-e77d72d73362">

Closes #2 